### PR TITLE
Modified string formatting for python 3.10

### DIFF
--- a/clinical-completeness-viz/completeness_stats.ipynb
+++ b/clinical-completeness-viz/completeness_stats.ipynb
@@ -306,7 +306,8 @@
     "    ax.barh(fields, percents)\n",
     "\n",
     "    ax.set_xlabel('Percent complete')\n",
-    "    ax.set_title(f'Completeness for required {schema_name} fields for {program_completeness_stats['program_id']}')\n",
+    "    program_id = program_completeness_stats['program_id']\n",
+    "    ax.set_title('Completeness for required {s} fields for {p}'.format(s=schema_name,p=program_id))\n",
     "\n",
     "    plt.show()"
    ]
@@ -327,8 +328,10 @@
    "outputs": [],
    "source": [
     "for program in completeness_data[2]['results']['programs']:\n",
-    "    display(Markdown(f'#### {program['program_id']} completeness per schema'))\n",
-    "    display(Markdown(f'{program['program_id']} does not have data for {\", \".join(program['metadata']['schemas_not_used'])}'))\n",
+    "    program_id = program_id=program['program_id']\n",
+    "    schemas_not_used = \", \".join(program['metadata']['schemas_not_used'])\n",
+    "    display(Markdown('#### {p} completeness per schema'.format(p=program_id)))\n",
+    "    display(Markdown('{p} does not have data for {s}'.format(p=program_id, s=schemas)))\n",
     "    \n",
     "    for schema in program['metadata']['schemas_used']:\n",
     "        if schema == \"exposures\":\n",
@@ -352,8 +355,10 @@
    "outputs": [],
    "source": [
     "for program in completeness_data[1]['results']['programs']:\n",
-    "    display(Markdown(f'#### {program['program_id']} completeness per schema'))\n",
-    "    display(Markdown(f'{program['program_id']} does not have data for {\", \".join(program['metadata']['schemas_not_used'])}'))\n",
+    "    program_id = program_id=program['program_id']\n",
+    "    schemas_not_used = \", \".join(program['metadata']['schemas_not_used'])\n",
+    "    display(Markdown('#### {p} completeness per schema'.format(p=program_id)))\n",
+    "    display(Markdown('{p} does not have data for {s}'.format(p=program_id, s=schemas)))\n",
     "    \n",
     "    for schema in program['metadata']['schemas_used']:\n",
     "        if schema == \"exposures\":\n",
@@ -377,14 +382,24 @@
    "outputs": [],
    "source": [
     "for program in completeness_data[0]['results']['programs']:\n",
-    "    display(Markdown(f'#### {program['program_id']} completeness per schema'))\n",
-    "    display(Markdown(f'{program['program_id']} does not have data for {\", \".join(program['metadata']['schemas_not_used'])}'))\n",
+    "    program_id = program_id=program['program_id']\n",
+    "    schemas_not_used = \", \".join(program['metadata']['schemas_not_used'])\n",
+    "    display(Markdown('#### {p} completeness per schema'.format(p=program_id)))\n",
+    "    display(Markdown('{p} does not have data for {s}'.format(p=program_id, s=schemas)))\n",
     "    \n",
     "    for schema in program['metadata']['schemas_used']:\n",
     "        if schema == \"exposures\":\n",
     "            continue\n",
     "        plot_by_schema_per_program(schema, program)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -403,7 +418,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.4"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Modified string formatting for compatibility with python 3.10. Versions earlier than 3.12 will complain about unmatched quotes when an f-string contains nested quotes. Switched to `.format` instead for in-string variables. 