### PR TITLE
Check for radiation dosage and fractions not available == true

### DIFF
--- a/mohccn-report/fullsome_treatments_radiation.sql
+++ b/mohccn-report/fullsome_treatments_radiation.sql
@@ -17,8 +17,10 @@ WHERE mohpackets_donor.program_id_id IS NOT NULL
   AND treatment_intent IS NOT NULL
   AND radiation_therapy_modality IS NOT NULL
   AND radiation_therapy_type IS NOT NULL
-  AND radiation_therapy_fractions IS NOT NULL
-  AND radiation_therapy_dosage IS NOT NULL
+  AND (radiation_therapy_fractions IS NOT NULL
+  OR radiation_therapy_fractions_not_available IS NOT NULL)
+  AND (radiation_therapy_dosage IS NOT NULL
+  OR radiation_therapy_dosage_not_available IS NOT NULL)
   AND anatomical_site_irradiated IS NOT NULL) TO '/tmp/fullsome_treatments_radiation_completeness.csv' with (FORMAT CSV, HEADER);
 COPY (SELECT program_id_id, submitter_donor_id, submitter_treatment_id, COUNT(*)
 FROM mohpackets_radiation

--- a/mohccn-report/fullsome_treatments_radiation.sql
+++ b/mohccn-report/fullsome_treatments_radiation.sql
@@ -19,9 +19,9 @@ WHERE mohpackets_donor.program_id_id IS NOT NULL
   AND radiation_therapy_modality IS NOT NULL
   AND radiation_therapy_type IS NOT NULL
   AND (radiation_therapy_fractions IS NOT NULL
-  OR radiation_therapy_fractions_not_available IS NOT NULL)
+  OR radiation_therapy_fractions_not_available)
   AND (radiation_therapy_dosage IS NOT NULL
-  OR radiation_therapy_dosage_not_available IS NOT NULL)
+  OR radiation_therapy_dosage_not_available)
   AND anatomical_site_irradiated IS NOT NULL) TO '/tmp/fullsome_treatments_radiation_completeness.csv' with (FORMAT CSV, HEADER);
 COPY (SELECT program_id_id, submitter_donor_id, submitter_treatment_id, COUNT(*)
 FROM mohpackets_radiation

--- a/mohccn-report/fullsome_treatments_radiation.sql
+++ b/mohccn-report/fullsome_treatments_radiation.sql
@@ -19,9 +19,9 @@ WHERE mohpackets_donor.program_id_id IS NOT NULL
   AND radiation_therapy_modality IS NOT NULL
   AND radiation_therapy_type IS NOT NULL
   AND (radiation_therapy_fractions IS NOT NULL
-  OR radiation_therapy_fractions_not_available)
+  OR radiation_therapy_fractions_not_available = TRUE)
   AND (radiation_therapy_dosage IS NOT NULL
-  OR radiation_therapy_dosage_not_available)
+  OR radiation_therapy_dosage_not_available = TRUE)
   AND anatomical_site_irradiated IS NOT NULL) TO '/tmp/fullsome_treatments_radiation_completeness.csv' with (FORMAT CSV, HEADER);
 COPY (SELECT program_id_id, submitter_donor_id, submitter_treatment_id, COUNT(*)
 FROM mohpackets_radiation

--- a/mohccn-report/fullsome_treatments_radiation.sql
+++ b/mohccn-report/fullsome_treatments_radiation.sql
@@ -1,6 +1,6 @@
 COPY (SELECT mohpackets_donor.program_id_id, mohpackets_donor.submitter_donor_id, mohpackets_primarydiagnosis.submitter_primary_diagnosis_id,
 mohpackets_treatment.submitter_treatment_id, treatment_type, radiation_therapy_fractions,
-radiation_therapy_fractions_not_available, radiation_therapy_dosage
+radiation_therapy_fractions_not_available, radiation_therapy_dosage,
 radiation_therapy_dosage_not_available
 FROM mohpackets_donor
 LEFT JOIN mohpackets_primarydiagnosis

--- a/mohccn-report/fullsome_treatments_radiation.sql
+++ b/mohccn-report/fullsome_treatments_radiation.sql
@@ -1,5 +1,6 @@
 COPY (SELECT mohpackets_donor.program_id_id, mohpackets_donor.submitter_donor_id, mohpackets_primarydiagnosis.submitter_primary_diagnosis_id,
-mohpackets_treatment.submitter_treatment_id, treatment_type
+mohpackets_treatment.submitter_treatment_id, treatment_type, radiation_therapy_fractions_not_available,
+radiation_therapy_dosage_not_available
 FROM mohpackets_donor
 LEFT JOIN mohpackets_primarydiagnosis
 ON mohpackets_donor.submitter_donor_id = mohpackets_primarydiagnosis.submitter_donor_id

--- a/mohccn-report/fullsome_treatments_radiation.sql
+++ b/mohccn-report/fullsome_treatments_radiation.sql
@@ -1,5 +1,6 @@
 COPY (SELECT mohpackets_donor.program_id_id, mohpackets_donor.submitter_donor_id, mohpackets_primarydiagnosis.submitter_primary_diagnosis_id,
-mohpackets_treatment.submitter_treatment_id, treatment_type, radiation_therapy_fractions_not_available,
+mohpackets_treatment.submitter_treatment_id, treatment_type, radiation_therapy_fractions,
+radiation_therapy_fractions_not_available, radiation_therapy_dosage
 radiation_therapy_dosage_not_available
 FROM mohpackets_donor
 LEFT JOIN mohpackets_primarydiagnosis


### PR DESCRIPTION
Bug reported by @dgaston-nsh

Script now pulls the extra `_not_available` columns for the required dosage and fractions fields in the Radiation object when it calculates fullsome completeness