### PR TITLE
End date can be blank if status_of_treatment == 'Treatment ongoing'

### DIFF
--- a/mohccn-report/fullsome_treatments.sql
+++ b/mohccn-report/fullsome_treatments.sql
@@ -13,7 +13,7 @@ WHERE mohpackets_donor.program_id_id IS NOT NULL
   AND is_primary_treatment IS NOT NULL
   AND treatment_start_date IS NOT NULL
   AND (treatment_end_date IS NOT NULL
-  OR status_of_treatment == "Treatment ongoing")
+  OR status_of_treatment == 'Treatment ongoing')
   AND treatment_intent IS NOT NULL
   ) TO '/tmp/fullsome_treatments_completeness.csv' with (FORMAT CSV, HEADER);
 COPY (SELECT program_id_id, submitter_donor_id, COUNT(*)

--- a/mohccn-report/fullsome_treatments.sql
+++ b/mohccn-report/fullsome_treatments.sql
@@ -13,7 +13,7 @@ WHERE mohpackets_donor.program_id_id IS NOT NULL
   AND is_primary_treatment IS NOT NULL
   AND treatment_start_date IS NOT NULL
   AND (treatment_end_date IS NOT NULL
-  OR status_of_treatment == 'Treatment ongoing')
+  OR status_of_treatment = 'Treatment ongoing')
   AND treatment_intent IS NOT NULL
   ) TO '/tmp/fullsome_treatments_completeness.csv' with (FORMAT CSV, HEADER);
 COPY (SELECT program_id_id, submitter_donor_id, COUNT(*)

--- a/mohccn-report/fullsome_treatments.sql
+++ b/mohccn-report/fullsome_treatments.sql
@@ -1,5 +1,5 @@
 COPY (SELECT mohpackets_donor.program_id_id, mohpackets_donor.submitter_donor_id, mohpackets_primarydiagnosis.submitter_primary_diagnosis_id,
-mohpackets_treatment.submitter_treatment_id, treatment_type
+mohpackets_treatment.submitter_treatment_id, treatment_type, status_of_treatment
 FROM
 mohpackets_donor
 LEFT JOIN mohpackets_primarydiagnosis
@@ -12,7 +12,8 @@ WHERE mohpackets_donor.program_id_id IS NOT NULL
   AND treatment_type IS NOT NULL
   AND is_primary_treatment IS NOT NULL
   AND treatment_start_date IS NOT NULL
-  AND treatment_end_date IS NOT NULL
+  AND (treatment_end_date IS NOT NULL
+  OR status_of_treatment == "Treatment ongoing")
   AND treatment_intent IS NOT NULL
   ) TO '/tmp/fullsome_treatments_completeness.csv' with (FORMAT CSV, HEADER);
 COPY (SELECT program_id_id, submitter_donor_id, COUNT(*)

--- a/mohccn-report/fullsome_treatments_sys_therapy.sql
+++ b/mohccn-report/fullsome_treatments_sys_therapy.sql
@@ -16,12 +16,12 @@ WHERE mohpackets_donor.program_id_id IS NOT NULL
   AND is_primary_treatment IS NOT NULL
   AND treatment_start_date IS NOT NULL
   AND (treatment_end_date IS NOT NULL
-  OR status_of_treatment == "Treatment ongoing")
+  OR status_of_treatment == 'Treatment ongoing')
   AND treatment_intent IS NOT NULL
   AND systemic_therapy_type IS NOT NULL
   AND start_date IS NOT NULL
   AND (end_date IS NOT NULL
-  OR status_of_treatment == "Treatment ongoing")
+  OR status_of_treatment == 'Treatment ongoing')
   AND drug_reference_database IS NOT NULL
   AND drug_reference_identifier IS NOT NULL
   AND drug_name IS NOT NULL) TO '/tmp/fullsome_treatments_sys_therapy_completeness.csv' with (FORMAT CSV, HEADER);

--- a/mohccn-report/fullsome_treatments_sys_therapy.sql
+++ b/mohccn-report/fullsome_treatments_sys_therapy.sql
@@ -14,11 +14,13 @@ WHERE mohpackets_donor.program_id_id IS NOT NULL
   AND treatment_type IS NOT NULL
   AND is_primary_treatment IS NOT NULL
   AND treatment_start_date IS NOT NULL
-  AND treatment_end_date IS NOT NULL
+  AND (treatment_end_date IS NOT NULL
+  OR status_of_treatment == "Treatment ongoing")
   AND treatment_intent IS NOT NULL
   AND systemic_therapy_type IS NOT NULL
   AND start_date IS NOT NULL
-  AND end_date IS NOT NULL
+  AND (end_date IS NOT NULL
+  OR status_of_treatment == "Treatment ongoing")
   AND drug_reference_database IS NOT NULL
   AND drug_reference_identifier IS NOT NULL
   AND drug_name IS NOT NULL) TO '/tmp/fullsome_treatments_sys_therapy_completeness.csv' with (FORMAT CSV, HEADER);

--- a/mohccn-report/fullsome_treatments_sys_therapy.sql
+++ b/mohccn-report/fullsome_treatments_sys_therapy.sql
@@ -16,12 +16,12 @@ WHERE mohpackets_donor.program_id_id IS NOT NULL
   AND is_primary_treatment IS NOT NULL
   AND treatment_start_date IS NOT NULL
   AND (treatment_end_date IS NOT NULL
-  OR status_of_treatment == 'Treatment ongoing')
+  OR status_of_treatment = 'Treatment ongoing')
   AND treatment_intent IS NOT NULL
   AND systemic_therapy_type IS NOT NULL
   AND start_date IS NOT NULL
   AND (end_date IS NOT NULL
-  OR status_of_treatment == 'Treatment ongoing')
+  OR status_of_treatment = 'Treatment ongoing')
   AND drug_reference_database IS NOT NULL
   AND drug_reference_identifier IS NOT NULL
   AND drug_name IS NOT NULL) TO '/tmp/fullsome_treatments_sys_therapy_completeness.csv' with (FORMAT CSV, HEADER);

--- a/mohccn-report/fullsome_treatments_sys_therapy.sql
+++ b/mohccn-report/fullsome_treatments_sys_therapy.sql
@@ -1,5 +1,6 @@
 COPY (SELECT mohpackets_donor.program_id_id, mohpackets_donor.submitter_donor_id, mohpackets_primarydiagnosis.submitter_primary_diagnosis_id,
-mohpackets_treatment.submitter_treatment_id, treatment_type, prescribed_cumulative_drug_dose, actual_cumulative_drug_dose, drug_dose_units
+mohpackets_treatment.submitter_treatment_id, treatment_type, prescribed_cumulative_drug_dose, actual_cumulative_drug_dose, drug_dose_units,
+status_of_treatment
 FROM mohpackets_donor
 LEFT JOIN mohpackets_primarydiagnosis
 ON mohpackets_donor.submitter_donor_id = mohpackets_primarydiagnosis.submitter_donor_id


### PR DESCRIPTION
Count treatments and systemic therapies as complete if they are missing an end date but the `status_of_treatment` == `Treatment ongoing`

Bug raised by @dgaston-nsh